### PR TITLE
Add YouTube support

### DIFF
--- a/site/src/components/PlayerLayout.tsx
+++ b/site/src/components/PlayerLayout.tsx
@@ -53,10 +53,9 @@ export default function PlayerLayout() {
     if (url.includes('spotify.com')) {
       return '/api/spotify/scrape';
     }
-    if (url.includes('bandcamp.com')) {
-      return '/api/bandcamp/scrape';
+    if (url.includes('youtube.com') || url.includes('youtu.be')) {
+      return '/api/youtube/scrape';
     }
-    // Default to bandcamp for backwards compatibility
     return '/api/bandcamp/scrape';
   };
 
@@ -137,7 +136,7 @@ export default function PlayerLayout() {
             <div className="flex flex-col gap-4 w-full max-w-md">
               <input
                 type="url"
-                placeholder="Paste Bandcamp or Spotify URL..."
+                placeholder="Paste Bandcamp, Spotify, or YouTube URL..."
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && handleSubmit()}

--- a/site/src/components/PlayerView.tsx
+++ b/site/src/components/PlayerView.tsx
@@ -50,15 +50,22 @@ function PlayerView({
         currentBlobUrlRef.current = null;
       }
 
-      // Get audio from cache or fetch from network
-      const audioUrl = await musicCache.getOrFetch(currentTrack.id, currentTrack.stream_url);
+      let audioUrl: string;
+
+      if (currentTrack.audio.type === 'youtube') {
+        audioUrl = `/api/youtube/stream?id=${currentTrack.audio.id}`;
+      } else {
+        audioUrl = await musicCache.getOrFetch(currentTrack.id, currentTrack.audio.url);
+        currentBlobUrlRef.current = audioUrl;
+      }
 
       if (cancelled) {
-        URL.revokeObjectURL(audioUrl);
+        if (currentBlobUrlRef.current) {
+          URL.revokeObjectURL(currentBlobUrlRef.current);
+        }
         return;
       }
 
-      currentBlobUrlRef.current = audioUrl;
       audio.src = audioUrl;
       audio.load();
 
@@ -84,7 +91,7 @@ function PlayerView({
       cancelled = true;
       audio.pause();
     };
-  }, [currentTrack.id, currentTrack.stream_url]);
+  }, [currentTrack.id, currentTrack.audio]);
 
   useEffect(() => {
     const audio = audioRef.current;

--- a/site/src/pages/api/bandcamp/scrape.ts
+++ b/site/src/pages/api/bandcamp/scrape.ts
@@ -97,7 +97,7 @@ function transformBandcampToFuckingPlaylist(
         name: trackInfo.title,
         artists: [trackInfo.artist || artist],
         tags: keywords.length > 0 ? keywords : undefined,
-        stream_url: streamUrl ?? '',
+        audio: { type: 'stream' as const, url: streamUrl ?? '' },
       };
     });
 

--- a/site/src/pages/api/youtube/scrape.ts
+++ b/site/src/pages/api/youtube/scrape.ts
@@ -1,0 +1,122 @@
+import type { APIRoute } from "astro";
+import type { PlaylistId, FuckingPlaylist, FuckingTrack, TrackId } from "../../../shared/types";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+interface YtDlpVideoInfo {
+  id: string;
+  title: string;
+  duration: number;
+  channel: string;
+  uploader: string;
+  thumbnail: string;
+  webpage_url: string;
+  playlist_title?: string;
+}
+
+export const GET: APIRoute = async ({ url }) => {
+  const youtubeUrl = url.searchParams.get("url");
+
+  if (!youtubeUrl) {
+    return new Response(
+      JSON.stringify({ error: "Missing 'url' query parameter" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  if (!youtubeUrl.includes("youtube.com") && !youtubeUrl.includes("youtu.be")) {
+    return new Response(
+      JSON.stringify({ error: "URL must be a YouTube URL" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  try {
+    const isPlaylist = youtubeUrl.includes("list=");
+    const cmd = isPlaylist
+      ? `yt-dlp -j --flat-playlist --no-warnings "${youtubeUrl}"`
+      : `yt-dlp -j --no-warnings "${youtubeUrl}"`;
+
+    const { stdout } = await execAsync(cmd, { maxBuffer: 10 * 1024 * 1024 });
+
+    let id: string;
+    let title: string;
+    let channel: string;
+    let thumbnail: string;
+    let videoTracks: { id: string; title: string; duration: number; channel: string }[];
+
+    if (isPlaylist) {
+      const lines = stdout.trim().split('\n').filter(line => line.trim());
+      const videos: YtDlpVideoInfo[] = lines.map(line => JSON.parse(line));
+
+      if (videos.length === 0) {
+        return new Response(
+          JSON.stringify({ error: "No videos found in playlist" }),
+          { status: 500, headers: { "Content-Type": "application/json" } }
+        );
+      }
+
+      const playlistIdMatch = youtubeUrl.match(/list=([a-zA-Z0-9_-]+)/);
+      id = playlistIdMatch ? playlistIdMatch[1] : "unknown";
+      title = videos[0]?.playlist_title || "YouTube Playlist";
+      channel = videos[0]?.channel || videos[0]?.uploader || "Unknown";
+      thumbnail = `https://img.youtube.com/vi/${videos[0]?.id}/maxresdefault.jpg`;
+      videoTracks = videos.map(video => ({
+        id: video.id,
+        title: video.title,
+        duration: video.duration || 0,
+        channel: video.channel || video.uploader || "Unknown",
+      }));
+    } else {
+      const video: YtDlpVideoInfo = JSON.parse(stdout);
+      id = video.id;
+      title = video.title;
+      channel = video.channel || video.uploader || "Unknown";
+      thumbnail = video.thumbnail || `https://img.youtube.com/vi/${video.id}/maxresdefault.jpg`;
+      videoTracks = [{
+        id: video.id,
+        title: video.title,
+        duration: video.duration || 0,
+        channel: video.channel || video.uploader || "Unknown",
+      }];
+    }
+
+    const playlistId: PlaylistId = `play-yt-${id}`;
+
+    const tracks: FuckingTrack[] = videoTracks.map((track) => ({
+      id: `track-yt-${track.id}` as TrackId,
+      time_ms: Math.round(track.duration * 1000),
+      name: track.title,
+      artists: [track.channel],
+      audio: { type: 'youtube' as const, id: track.id },
+    }));
+
+    for (let i = 0; i < tracks.length - 1; i++) {
+      tracks[i].next_tracks = { [playlistId]: tracks[i + 1].id };
+    }
+
+    const playlist: FuckingPlaylist = {
+      id: playlistId,
+      track_cover_uri: thumbnail,
+      name: title,
+      artists: [channel],
+      first_track: tracks[0],
+    };
+
+    return new Response(JSON.stringify({ playlist, tracks }, null, 2), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("Error scraping YouTube:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Failed to scrape YouTube",
+        details: error instanceof Error ? error.message : String(error)
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+};

--- a/site/src/pages/api/youtube/stream.ts
+++ b/site/src/pages/api/youtube/stream.ts
@@ -1,0 +1,66 @@
+import type { APIRoute } from "astro";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+export const GET: APIRoute = async ({ url }) => {
+  const videoId = url.searchParams.get("id");
+
+  if (!videoId) {
+    return new Response(
+      JSON.stringify({ error: "Missing 'id' query parameter" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  if (!/^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
+    return new Response(
+      JSON.stringify({ error: "Invalid video ID format" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  try {
+    const { stdout } = await execAsync(
+      `yt-dlp -f "bestaudio[ext=m4a]/bestaudio/best" -g --no-warnings "https://www.youtube.com/watch?v=${videoId}"`,
+      { maxBuffer: 1024 * 1024 }
+    );
+    const streamUrl = stdout.trim();
+
+    if (!streamUrl) {
+      return new Response(
+        JSON.stringify({ error: "Could not get stream URL" }),
+        { status: 500, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const audioResponse = await fetch(streamUrl);
+
+    if (!audioResponse.ok) {
+      return new Response(
+        JSON.stringify({ error: "Failed to fetch audio stream" }),
+        { status: 502, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    return new Response(audioResponse.body, {
+      status: 200,
+      headers: {
+        "Content-Type": audioResponse.headers.get("Content-Type") || "audio/mp4",
+        "Content-Length": audioResponse.headers.get("Content-Length") || "",
+        "Accept-Ranges": "bytes",
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
+  } catch (error) {
+    console.error("Error streaming YouTube audio:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Failed to stream audio",
+        details: error instanceof Error ? error.message : String(error)
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+};

--- a/site/src/shared/types.ts
+++ b/site/src/shared/types.ts
@@ -34,13 +34,17 @@ export interface BandcampPageData {
   keywords?: string[];
 }
 
+export type AudioSource =
+  | { type: 'stream'; url: string }
+  | { type: 'youtube'; id: string };
+
 export interface FuckingTrack {
   id: TrackId;
   time_ms: number;
   name: string;
   artists: string[];
   tags?: string[];
-  stream_url: string;
+  audio: AudioSource;
   next_tracks?: Record<PlaylistId, TrackId>;
 }
 
@@ -50,3 +54,4 @@ export interface PlayerState {
   trackTimestamp: number;
   lastPlaylistId: PlaylistId;
 }
+


### PR DESCRIPTION
## Summary
- Add YouTube video/playlist support via yt-dlp
- Store video IDs instead of expiring stream URLs
- Stream audio on-demand through `/api/youtube/stream`

## Test plan
- [ ] Paste a YouTube video URL and verify it loads
- [ ] Paste a YouTube playlist URL and verify tracks load
- [ ] Verify audio plays correctly
- [ ] Verify Bandcamp still works