### PR TITLE
feat: Add bottom playing indicator component

### DIFF
--- a/site/src/components/NowPlayingIndicator.tsx
+++ b/site/src/components/NowPlayingIndicator.tsx
@@ -59,4 +59,3 @@ export const NowPlayingIndicator = ({
         </div>
     )
 }
-

--- a/site/src/components/NowPlayingIndicatorDemo.tsx
+++ b/site/src/components/NowPlayingIndicatorDemo.tsx
@@ -41,4 +41,3 @@ export const NowPlayingIndicatorDemo = () => {
         />
     )
 }
-

--- a/site/src/components/ui/AudioBars.tsx
+++ b/site/src/components/ui/AudioBars.tsx
@@ -8,4 +8,3 @@ export const AudioBars = () => {
         </div>
     )
 }
-

--- a/site/src/pages/indicator-demo.astro
+++ b/site/src/pages/indicator-demo.astro
@@ -13,4 +13,3 @@ import { NowPlayingIndicatorDemo } from "../components/NowPlayingIndicatorDemo"
     </main>
     <NowPlayingIndicatorDemo client:load />
 </Layout>
-

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -8,23 +8,43 @@
 
 /* Audio bar animations for now playing indicator */
 @keyframes audio-bar-1 {
-    0%, 100% { height: 4px; }
-    50% { height: 12px; }
+    0%,
+    100% {
+        height: 4px;
+    }
+    50% {
+        height: 12px;
+    }
 }
 
 @keyframes audio-bar-2 {
-    0%, 100% { height: 8px; }
-    50% { height: 4px; }
+    0%,
+    100% {
+        height: 8px;
+    }
+    50% {
+        height: 4px;
+    }
 }
 
 @keyframes audio-bar-3 {
-    0%, 100% { height: 6px; }
-    50% { height: 14px; }
+    0%,
+    100% {
+        height: 6px;
+    }
+    50% {
+        height: 14px;
+    }
 }
 
 @keyframes audio-bar-4 {
-    0%, 100% { height: 10px; }
-    50% { height: 6px; }
+    0%,
+    100% {
+        height: 10px;
+    }
+    50% {
+        height: 6px;
+    }
 }
 
 .animate-audio-bar-1 {


### PR DESCRIPTION
Implements issue #15

Creates a standalone bottom indicator component that displays the currently playing song with animations.

## Changes:
- Created NowPlayingIndicator component
- Created AudioBars component with animations  
- Added CSS keyframe animations
- Created demo page at /indicator-demo

Closes #15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a fixed bottom Now Playing indicator with progress and play/pause, animated audio bars, and a demo page.
> 
> - **UI**:
>   - Add `NowPlayingIndicator` (`site/src/components/NowPlayingIndicator.tsx`) showing current track info, playlist cover, top progress bar, and play/pause; overlays animated `AudioBars` when playing.
>   - Add `AudioBars` (`site/src/components/ui/AudioBars.tsx`).
>   - Add demo component and page `indicator-demo.astro` with mock data and simulated progress (`site/src/components/NowPlayingIndicatorDemo.tsx`, `site/src/pages/indicator-demo.astro`).
> - **Styles**:
>   - Add keyframe animations and classes for audio bars and slow pulse in `site/src/styles/global.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16c4adc61058042470d9f74d546e28551bb982a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->