### PR TITLE
Useeffect sigma logic

### DIFF
--- a/graph-frontend/src/components/Graph.tsx
+++ b/graph-frontend/src/components/Graph.tsx
@@ -36,10 +36,10 @@ export function Graph({ layout, isDark }: { layout: LayoutMode; isDark: boolean 
 
   useEffect(() => {
     if (graph) {
-      sigma.refresh()
       loadGraph(graph)
+      sigma.refresh()
     }
-  }, [graph, layout, loadGraph])
+  }, [graph, layout, loadGraph, sigma])
 
   const maxMetric = useMemo(() => {
     if (!nodeMetrics) return 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reorder `loadGraph` and `sigma.refresh` calls and add `sigma` to the `useEffect` dependency array.

The previous order caused `sigma.refresh()` to run with the old graph state, leading to a wasted refresh and potential visual flash. Additionally, `sigma` was missing from the dependency array, preventing the effect from re-running if the `sigma` instance changed.

---
<p><a href="https://cursor.com/agents/bc-e2794d05-06c5-4e4f-8e89-6ba5c2f5475c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2794d05-06c5-4e4f-8e89-6ba5c2f5475c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->