### PR TITLE
[cdxker] Add phone radio playlist selection

### DIFF
--- a/phone-radio/README.md
+++ b/phone-radio/README.md
@@ -3,7 +3,7 @@
 Express webhook server for Vonage Voice API inbound calls.
 
 Vonage calls `/answer`, receives an NCCO, then streams MP3 files from `~/Music` into the call.
-During playback, pressing `1` queues the previous track, pressing `2` skips to the next track, and pressing `9` opens playlist selection.
+During playback, pressing `1` queues the previous track, pressing `2` skips to the next track, and pressing `#` opens playlist selection.
 
 ## Run
 
@@ -84,7 +84,7 @@ The answer webhook returns:
 
 When `/answer` receives the call UUID from Vonage, the server stores `listener:{uuid}:playlist` and `listener:{uuid}:track` in Redis and queues one track from playlist `1`. The notify callback includes the playlist number, advances matching current playback, and returns the next one-track NCCO.
 
-The NCCO also registers `/input/digit` for DTMF input. Pressing `1` moves backward and pressing `2` advances within the active playlist. Pressing `9` transfers the call to a selector prompt that says "Press any number followed by the pound sign." The selector uses Vonage DTMF `submitOnHash` and posts to `/input/playlist`; valid playlist numbers switch the caller to that playlist at track `0`, while invalid input returns to current playback.
+The NCCO also registers `/input/digit` for DTMF input. Pressing `1` moves backward and pressing `2` advances within the active playlist. Pressing `#` transfers the call to a selector prompt that says "Press the playlist number followed by the pound sign." The selector uses Vonage DTMF `submitOnHash` and posts to `/input/playlist`; valid playlist numbers switch the caller to that playlist at track `0`, while invalid input returns to current playback.
 
 Put your Vonage private key at `phone-radio/private.key`. It is ignored by git.
 

--- a/phone-radio/README.md
+++ b/phone-radio/README.md
@@ -3,7 +3,7 @@
 Express webhook server for Vonage Voice API inbound calls.
 
 Vonage calls `/answer`, receives an NCCO, then streams MP3 files from `~/Music` into the call.
-During playback, pressing `1` queues the previous track and pressing `2` skips to the next track.
+During playback, pressing `1` queues the previous track, pressing `2` skips to the next track, and pressing `9` opens playlist selection.
 
 ## Run
 
@@ -68,7 +68,7 @@ The answer webhook returns:
   },
   {
     "action": "stream",
-    "streamUrl": ["https://YOUR_NGROK_URL/track/0?secret=YOUR_SECRET"],
+    "streamUrl": ["https://YOUR_NGROK_URL/track/1/0?secret=YOUR_SECRET"],
     "loop": 1
   },
   {
@@ -76,15 +76,15 @@ The answer webhook returns:
     "payload": {
       "uuid": "CALL_UUID"
     },
-    "eventUrl": ["https://YOUR_NGROK_URL/track/finished/CALL_UUID"],
+    "eventUrl": ["https://YOUR_NGROK_URL/track/finished/CALL_UUID/1/0"],
     "eventMethod": "POST"
   }
 ]
 ```
 
-When `/answer` receives the call UUID from Vonage, the server stores `listener:{uuid}:track` in Redis and queues one track. The notify callback advances that Redis index and returns the next one-track NCCO.
+When `/answer` receives the call UUID from Vonage, the server stores `listener:{uuid}:playlist` and `listener:{uuid}:track` in Redis and queues one track from playlist `1`. The notify callback includes the playlist number, advances matching current playback, and returns the next one-track NCCO.
 
-The NCCO also registers `/input/digit` for DTMF input. Pressing `1` moves the Redis index backward and transfers the active call to a new NCCO that announces the queued song index before starting the previous track. Pressing `2` advances the Redis index and transfers the active call to a new NCCO that announces the queued song index before starting the next track.
+The NCCO also registers `/input/digit` for DTMF input. Pressing `1` moves backward and pressing `2` advances within the active playlist. Pressing `9` transfers the call to a selector prompt that says "Press any number followed by the pound sign." The selector uses Vonage DTMF `submitOnHash` and posts to `/input/playlist`; valid playlist numbers switch the caller to that playlist at track `0`, while invalid input returns to current playback.
 
 Put your Vonage private key at `phone-radio/private.key`. It is ignored by git.
 

--- a/phone-radio/scripts/tracks-to-song-list.ts
+++ b/phone-radio/scripts/tracks-to-song-list.ts
@@ -2,15 +2,21 @@ import { writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { tracks } from '../src/tracks.ts';
+import { playlists } from '../src/playlists/index.ts';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const outputPath = resolve(scriptDir, '..', process.argv[2] ?? 'song-list.txt');
 const musicRoot = '/home/cdxker/Music/Ricky/';
 
-const content = `${tracks
-  .map((track, index) => `${index + 1}. ${track.startsWith(musicRoot) ? track.slice(musicRoot.length) : track}`)
-  .join('\n\n')}\n`;
+const playlistLines = playlists.flatMap((playlist) => [
+  `# ${playlist.number}. ${playlist.name}`,
+  ...playlist.tracks.map(
+    (track, index) =>
+      `${index + 1}. ${track.startsWith(musicRoot) ? track.slice(musicRoot.length) : track}`,
+  ),
+]);
+
+const content = `${playlistLines.join('\n\n')}\n`;
 
 writeFileSync(outputPath, content, 'utf8');
-console.log(`Wrote ${tracks.length} tracks to ${outputPath}`);
+console.log(`Wrote ${playlistLines.length} playlist lines to ${outputPath}`);

--- a/phone-radio/src/playlist.service.ts
+++ b/phone-radio/src/playlist.service.ts
@@ -1,7 +1,11 @@
 import { redisClient } from "./clients.js";
 import Redis from "ioredis";
-import { tracks } from "./tracks.js";
 import { stat } from "node:fs/promises";
+import {
+  DEFAULT_PLAYLIST_NUMBER,
+  playlists,
+  type Playlist,
+} from "./playlists/index.js";
 
 export type Track = {
   filePath: string;
@@ -10,40 +14,67 @@ export type Track = {
 
 export type PlaylistTrack = Track & {
   index: number;
+  playlistNumber: string;
+  playlistName: string;
 };
+
+const PLAYBACK_MODE = "playing";
+const PLAYLIST_SELECTION_MODE = "selecting-playlist";
 
 class PlaylistService {
   constructor(public readonly redisClient: Redis.Redis) {}
 
   public async startPlaylist(uuid: string): Promise<void> {
-    await this.redisClient.set(`listener:${uuid}:track`, "0");
+    await this.redisClient
+      .pipeline()
+      .set(this.playlistKey(uuid), DEFAULT_PLAYLIST_NUMBER)
+      .set(this.trackKey(uuid), "0")
+      .set(`listener:${uuid}:mode`, PLAYBACK_MODE)
+      .exec();
+  }
+
+  public async startPlaylistSelection(uuid: string): Promise<void> {
+    await this.redisClient.set(
+      `listener:${uuid}:mode`,
+      PLAYLIST_SELECTION_MODE,
+    );
+  }
+
+  public async resumePlayback(uuid: string): Promise<void> {
+    await this.redisClient.set(`listener:${uuid}:mode`, PLAYBACK_MODE);
   }
 
   public async getCurrentTrack(uuid: string): Promise<PlaylistTrack | null> {
     try {
-      let trackIndex = await this.redisClient.get(`listener:${uuid}:track`);
+      const currentState = await this.getCurrentState(uuid);
 
-      if (!trackIndex) return null;
-
-      const index = parseInt(trackIndex);
-
-      return {
-        filePath: tracks[index],
-        fileSize: (await stat(tracks[index])).size,
-        index,
-      };
+      return currentState ? this.getPlaylistTrack(currentState) : null;
     } catch (error) {
       return null;
     }
   }
 
-  public async getTrackPath(songIndex: number): Promise<Track | null> {
-    const filePath = tracks[songIndex];
+  public async getTrackPath(
+    playlistNumber: string,
+    songIndex: number,
+  ): Promise<Track | null> {
+    const playlist = this.getPlaylistByNumber(playlistNumber);
+
+    if (!playlist) {
+      return null;
+    }
+
+    const filePath = playlist.tracks[songIndex];
+
+    if (!filePath) {
+      return null;
+    }
+
     try {
       const trackStat = await stat(filePath);
 
       return {
-        filePath: tracks[songIndex],
+        filePath,
         fileSize: trackStat.size,
       };
     } catch (error) {
@@ -53,64 +84,204 @@ class PlaylistService {
 
   public async trackFinished(
     uuid: string,
+    completedPlaylistNumber: string,
     completedSongIndex: number,
   ): Promise<PlaylistTrack | null> {
-    const currentTrack = await this.getCurrentTrack(uuid);
+    const playbackMode =
+      (await this.redisClient.get(`listener:${uuid}:mode`)) ?? PLAYBACK_MODE;
 
-    if (!currentTrack) {
+    if (playbackMode !== PLAYBACK_MODE) {
       return null;
     }
 
-    if (currentTrack.index !== completedSongIndex) {
+    const currentState = await this.getCurrentState(uuid);
+
+    if (!currentState) {
       return null;
     }
 
-    const nextTrackIndex = (completedSongIndex + 1) % tracks.length;
+    if (
+      currentState.playlist.number !== completedPlaylistNumber ||
+      currentState.index !== completedSongIndex
+    ) {
+      return null;
+    }
 
-    return this.setToTrack(uuid, nextTrackIndex);
+    const nextTrackIndex =
+      (completedSongIndex + 1) % currentState.playlist.tracks.length;
+
+    return this.commitTrack(uuid, currentState.playlist.number, nextTrackIndex);
   }
 
-  private async setToTrack(
+  public async commitTrack(
     uuid: string,
+    playlistNumber: string,
     index: number,
   ): Promise<PlaylistTrack | null> {
-    const filePath = tracks[index];
+    const playlist = this.getPlaylistByNumber(playlistNumber);
+
+    if (!playlist) {
+      return null;
+    }
+
+    try {
+      const playlistTrack = await this.getPlaylistTrack({ playlist, index });
+
+      if (!playlistTrack) {
+        return null;
+      }
+
+      await this.redisClient.set(this.playlistKey(uuid), playlist.number);
+      await this.redisClient.set(this.trackKey(uuid), index.toString());
+      await this.redisClient.set(`listener:${uuid}:mode`, PLAYBACK_MODE);
+
+      return playlistTrack;
+    } catch {
+      return null;
+    }
+  }
+
+  public async getNextTrack(uuid: string): Promise<PlaylistTrack | null> {
+    const currentState = await this.getCurrentState(uuid);
+    if (!currentState) {
+      return null;
+    }
+    const nextTrackIndex =
+      (currentState.index + 1 + currentState.playlist.tracks.length) %
+      currentState.playlist.tracks.length;
+
+    return this.getPlaylistTrack({
+      playlist: currentState.playlist,
+      index: nextTrackIndex,
+    });
+  }
+
+  public async getPreviousTrack(uuid: string): Promise<PlaylistTrack | null> {
+    const currentState = await this.getCurrentState(uuid);
+    if (!currentState) {
+      return null;
+    }
+    const nextTrackIndex =
+      (currentState.index - 1 + currentState.playlist.tracks.length) %
+      currentState.playlist.tracks.length;
+
+    return this.getPlaylistTrack({
+      playlist: currentState.playlist,
+      index: nextTrackIndex,
+    });
+  }
+
+  public async switchPlaylistByNumber(
+    uuid: string,
+    playlistNumber: string | undefined,
+  ): Promise<PlaylistTrack | null> {
+    const playlist = this.getPlaylistByNumber(playlistNumber);
+
+    if (!playlist) {
+      return null;
+    }
+
+    return this.commitTrack(uuid, playlist.number, 0);
+  }
+
+  /**
+   * Convenience wrappers for non-transfer callers. Digit routes should preview
+   * with getNextTrack/getPreviousTrack, transfer, then commit the track.
+   */
+  public async toNextTrack(uuid: string): Promise<PlaylistTrack | null> {
+    const nextTrack = await this.getNextTrack(uuid);
+
+    return nextTrack
+      ? this.commitTrack(uuid, nextTrack.playlistNumber, nextTrack.index)
+      : null;
+  }
+
+  public async toPreviousTrack(uuid: string): Promise<PlaylistTrack | null> {
+    const previousTrack = await this.getPreviousTrack(uuid);
+
+    return previousTrack
+      ? this.commitTrack(uuid, previousTrack.playlistNumber, previousTrack.index)
+      : null;
+  }
+
+  private playlistKey(uuid: string): string {
+    return `listener:${uuid}:playlist`;
+  }
+
+  private trackKey(uuid: string): string {
+    return `listener:${uuid}:track`;
+  }
+
+  private async getCurrentState(
+    uuid: string,
+  ): Promise<{ playlist: Playlist; index: number } | null> {
+    const [storedPlaylistNumber, trackIndex] = await Promise.all([
+      this.redisClient.get(this.playlistKey(uuid)),
+      this.redisClient.get(this.trackKey(uuid)),
+    ]);
+
+    if (!trackIndex) {
+      return null;
+    }
+
+    const index = Number.parseInt(trackIndex, 10);
+    const playlist = this.getPlaylistByNumber(
+      storedPlaylistNumber ?? DEFAULT_PLAYLIST_NUMBER,
+    );
+
+    if (!playlist || !Number.isInteger(index)) {
+      return null;
+    }
+
+    if (index < 0 || index >= playlist.tracks.length) {
+      return null;
+    }
+
+    return { playlist, index };
+  }
+
+  private async getPlaylistTrack({
+    playlist,
+    index,
+  }: {
+    playlist: Playlist;
+    index: number;
+  }): Promise<PlaylistTrack | null> {
+    const filePath = playlist.tracks[index];
+
+    if (!filePath) {
+      return null;
+    }
 
     try {
       const fileSize = (await stat(filePath)).size;
-
-      await this.redisClient.set(`listener:${uuid}:track`, index);
 
       return {
         filePath,
         fileSize,
         index,
+        playlistNumber: playlist.number,
+        playlistName: playlist.name,
       };
     } catch {
       return null;
     }
   }
 
-  public async toNextTrack(uuid: string): Promise<PlaylistTrack | null> {
-    const currentTrack = await this.getCurrentTrack(uuid);
-    if (!currentTrack) {
+  private getPlaylistByNumber(input: string | undefined): Playlist | null {
+    const playlistNumber = this.normalizePlaylistNumber(input);
+
+    if (!playlistNumber) {
       return null;
     }
-    const nextTrackIndex =
-      (currentTrack.index + 1 + tracks.length) % tracks.length;
 
-    return this.setToTrack(uuid, nextTrackIndex);
+    return (
+      playlists.find((playlist) => playlist.number === playlistNumber) ?? null
+    );
   }
 
-  public async toPreviousTrack(uuid: string): Promise<PlaylistTrack | null> {
-    const currentTrack = await this.getCurrentTrack(uuid);
-    if (!currentTrack) {
-      return null;
-    }
-    const nextTrackIndex =
-      (currentTrack.index - 1 + tracks.length) % tracks.length;
-
-    return this.setToTrack(uuid, nextTrackIndex);
+  private normalizePlaylistNumber(input: string | undefined): string {
+    return (input ?? "").replace(/\D/g, "");
   }
 }
 

--- a/phone-radio/src/playlists/default.ts
+++ b/phone-radio/src/playlists/default.ts
@@ -1,4 +1,4 @@
-export const tracks = [
+export const defaultTracks = [
   "/home/cdxker/Music/Ricky/DeeBaby - Marz (Exclusive By： @HalfpintFilmz) [Bmy2CPU4j0Y].mp3",
   "/home/cdxker/Music/Ricky/U.O.E.N.O. (Feat. Future, Rick Ross, A$AP Rocky & Wiz Khalifa) [6I6eGVyBhGU].mp3",
   "/home/cdxker/Music/Ricky/Finesse2Tymes - Overdose [Official Music Video] [xbGprczzCFw].mp3",

--- a/phone-radio/src/playlists/index.ts
+++ b/phone-radio/src/playlists/index.ts
@@ -1,0 +1,45 @@
+import { defaultTracks } from "./default.js";
+
+export type Playlist = {
+  number: string;
+  name: string;
+  tracks: string[];
+};
+
+export const DEFAULT_PLAYLIST_NUMBER = "1";
+
+export const playlists: Playlist[] = [
+  {
+    number: DEFAULT_PLAYLIST_NUMBER,
+    name: "Default",
+    tracks: defaultTracks,
+  },
+  {
+    number: "2",
+    name: "Playlist 2",
+    tracks: [
+      "/home/cdxker/Music/Ricky/Fyri/imstilldead_.mp3",
+      "/home/cdxker/Music/Ricky/Fyri/_nightofthedead.mp3",
+      "/home/cdxker/Music/Ricky/Fyri/Backfromthe_dead.mp3",
+      "/home/cdxker/Music/Ricky/EnerJazz  - ECSTASY (feat. Fyri) [OFFICIAL AUDIO] [XGQ95A5Vfj4].mp3",
+      "/home/cdxker/Music/Ricky/Yuki lyric video [q62CquC4DK8].mp3",
+      "/home/cdxker/Music/Ricky/Whatcha feel official lyric video [G_6ZfSCYnSU].mp3",
+      "/home/cdxker/Music/Ricky/God Mode Reached [Zf1Pyb7k-9I].mp3",
+      "/home/cdxker/Music/Ricky/DestroyLonely- too many [zyELJlR2ucc].mp3",
+      "/home/cdxker/Music/Ricky/Diggy Graves - Red Vineyard [Official Lyric Video] [8Ro085T0mnQ].mp3",
+      "/home/cdxker/Music/Ricky/Diggy Graves - Cute Girl [Official Lyric Video] [5_guj-NSG8U].mp3",
+      "/home/cdxker/Music/Ricky/Diggy Graves - Industry Flower [Official Lyric Video] [tWe_nVTaBuo].mp3",
+      "/home/cdxker/Music/Ricky/Diggy Graves - Dear Dracula, [Official Lyric Video] [8BLL1E_x6Qs].mp3",
+      "/home/cdxker/Music/Ricky/ppcocaine - BMPU (8D Tunez) [2WUMW4V6KKc].mp3",
+      "/home/cdxker/Music/Ricky/ppcocaine - S.L.U.T. (Official Music Video) [QXCNEvRHmxk].mp3",
+      "/home/cdxker/Music/Ricky/Ashnikko - Deal With It (feat. Kelis) [Official Music Video] [DXGelmwqfm4].mp3",
+      "/home/cdxker/Music/Ricky/Ashnikko - Halloweenie (Official Music Video) [iqSt1ZS_Znw].mp3",
+      "/home/cdxker/Music/Ricky/Ashnikko - Halloweenie II： Pumpkin Spice (Official Music Video) [2sZIaNwFzRc].mp3",
+      "/home/cdxker/Music/Ricky/Ashnikko – Halloweenie III： Seven Days (Official Music Video) [2qJa_5hp06g].mp3",
+      "/home/cdxker/Music/Ricky/Ashnikko - Halloweenie IV： Innards ｜ Lyrics [XfuzpA3E2Yc].mp3",
+      "/home/cdxker/Music/Ricky/Kkallabassass [asO8OAXLYsI].mp3",
+      "/home/cdxker/Music/Ricky/Teddy Hyde - Sex With A Ghost [AGKcT5vlRkE].mp3",
+      "/home/cdxker/Music/Ricky/＂Any Kind of Dead Person＂ from Ghost Quartet [x42OuR1bCow].mp3",
+    ],
+  },
+];

--- a/phone-radio/src/routes.ts
+++ b/phone-radio/src/routes.ts
@@ -158,14 +158,14 @@ routes.post("/input/digit", async (req, res) => {
 
   let nextTrack: PlaylistTrack | null = null;
 
-  if (digit !== "1" && digit !== "2" && digit !== "9") {
+  if (digit !== "1" && digit !== "2" && digit !== "#") {
     res.status(400).json({
       error: "Invalid digit.",
     });
     return;
   }
 
-  if (digit === "9") {
+  if (digit === "#") {
     try {
       await playlistService.startPlaylistSelection(uuid);
       await voiceClient.transferCallWithNCCO(

--- a/phone-radio/src/routes.ts
+++ b/phone-radio/src/routes.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import type { Router as ExpressRouter } from "express";
 import { voiceClient } from "./clients.js";
 import { playlistService, type PlaylistTrack } from "./playlist.service.js";
+import { buildPlaylistSelectionNcco } from "./utils/buildPlaylistSelectionNcco.js";
 import { buildTrackNcco } from "./utils/buildTrackNcco.js";
 
 export const routes: ExpressRouter = Router();
@@ -31,6 +32,14 @@ routes.post("/answer", async (req, res) => {
   } = request;
 
   await playlistService.startPlaylist(uuid);
+  const currentTrack = await playlistService.getCurrentTrack(uuid);
+
+  if (!currentTrack) {
+    res.status(404).json({
+      error: "Default playlist track could not be found.",
+    });
+    return;
+  }
 
   setTimeout(() => {
     const digitPressUrl = new URL("/input/digit", url);
@@ -43,12 +52,21 @@ routes.post("/answer", async (req, res) => {
     void voiceClient.playDTMF(uuid, "1");
   }, 5_000);
 
-  res.json(buildTrackNcco({ url, uuid, trackIndex: 0, announceTrack: false }));
+  res.json(
+    buildTrackNcco({
+      url,
+      uuid,
+      playlistNumber: currentTrack.playlistNumber,
+      trackIndex: currentTrack.index,
+      announceTrack: false,
+    }),
+  );
 });
 
 const finishedTrackRequestParser = type({
   params: {
     uuid: "string",
+    playlistNumber: "string",
     songIndex: "string",
   },
   locals: {
@@ -56,51 +74,56 @@ const finishedTrackRequestParser = type({
   },
 });
 
-routes.post("/track/finished/:uuid/:songIndex", async (req, res) => {
-  const request = finishedTrackRequestParser(req);
-  if (request instanceof type.errors) {
-    res.status(400).json({
-      error: request.summary,
-    });
-    return;
-  }
+routes.post(
+  "/track/finished/:uuid/:playlistNumber/:songIndex",
+  async (req, res) => {
+    const request = finishedTrackRequestParser(req);
+    if (request instanceof type.errors) {
+      res.status(400).json({
+        error: request.summary,
+      });
+      return;
+    }
 
-  const {
-    params: { songIndex, uuid },
-    locals: { baseUrl: url },
-  } = request;
+    const {
+      params: { playlistNumber, songIndex, uuid },
+      locals: { baseUrl: url },
+    } = request;
 
-  const finishedTrackIndex = parseInt(songIndex);
-  if (!Number.isInteger(finishedTrackIndex)) {
-    res.status(400).json({
-      error: "Invalid finished track index.",
-    });
-    return;
-  }
+    const finishedTrackIndex = parseInt(songIndex);
+    if (!Number.isInteger(finishedTrackIndex)) {
+      res.status(400).json({
+        error: "Invalid finished track index.",
+      });
+      return;
+    }
 
-  const nextTrack = await playlistService.trackFinished(
-    uuid,
-    finishedTrackIndex,
-  );
-
-  if (nextTrack === null) {
-    req.log.info(
-      { finishedTrackIndex, uuid },
-      "Ignored duplicate finished track webhook",
-    );
-    res.status(204).send();
-    return;
-  }
-
-  res.json(
-    buildTrackNcco({
-      url,
+    const nextTrack = await playlistService.trackFinished(
       uuid,
-      trackIndex: nextTrack.index,
-      announceTrack: false,
-    }),
-  );
-});
+      playlistNumber,
+      finishedTrackIndex,
+    );
+
+    if (nextTrack === null) {
+      req.log.info(
+        { finishedPlaylistNumber: playlistNumber, finishedTrackIndex, uuid },
+        "Ignored duplicate finished track webhook",
+      );
+      res.status(204).send();
+      return;
+    }
+
+    res.json(
+      buildTrackNcco({
+        url,
+        uuid,
+        playlistNumber: nextTrack.playlistNumber,
+        trackIndex: nextTrack.index,
+        announceTrack: false,
+      }),
+    );
+  },
+);
 
 const digitInputRequestParser = type({
   query: {
@@ -135,19 +158,42 @@ routes.post("/input/digit", async (req, res) => {
 
   let nextTrack: PlaylistTrack | null = null;
 
-  if (digit !== "1" && digit !== "2") {
+  if (digit !== "1" && digit !== "2" && digit !== "9") {
     res.status(400).json({
       error: "Invalid digit.",
     });
     return;
   }
 
+  if (digit === "9") {
+    try {
+      await playlistService.startPlaylistSelection(uuid);
+      await voiceClient.transferCallWithNCCO(
+        uuid,
+        buildPlaylistSelectionNcco({ url, uuid }),
+      );
+
+      req.log.info({ digit, uuid }, "Transferred call to playlist selector");
+      res.status(204).send();
+    } catch (error: unknown) {
+      req.log.error(
+        { error, uuid },
+        "Failed to transfer call to playlist selector",
+      );
+      await playlistService.resumePlayback(uuid);
+      res.status(502).json({
+        error: "Failed to transfer call to playlist selector.",
+      });
+    }
+    return;
+  }
+
   if (digit === "1") {
-    nextTrack = await playlistService.toPreviousTrack(uuid);
+    nextTrack = await playlistService.getPreviousTrack(uuid);
   }
 
   if (digit === "2") {
-    nextTrack = await playlistService.toNextTrack(uuid);
+    nextTrack = await playlistService.getNextTrack(uuid);
   }
 
   if (nextTrack === null) {
@@ -163,20 +209,48 @@ routes.post("/input/digit", async (req, res) => {
       buildTrackNcco({
         url,
         uuid,
+        playlistNumber: nextTrack.playlistNumber,
         trackIndex: nextTrack.index,
         announceTrack: true,
       }),
     );
 
+    const committedTrack = await playlistService.commitTrack(
+      uuid,
+      nextTrack.playlistNumber,
+      nextTrack.index,
+    );
+
+    if (committedTrack === null) {
+      req.log.error(
+        { uuid, nextTrackIndex: nextTrack.index },
+        "Failed to commit queued phone radio track after transfer",
+      );
+      res.status(500).json({
+        error: "Failed to commit queued track.",
+      });
+      return;
+    }
+
     req.log.info(
-      { digit, uuid, nextTrackIndex: nextTrack.index },
+      {
+        digit,
+        nextPlaylistNumber: nextTrack.playlistNumber,
+        nextTrackIndex: nextTrack.index,
+        uuid,
+      },
       "Transferred call to queued phone radio track",
     );
 
     res.status(204).send();
   } catch (error: unknown) {
     req.log.error(
-      { error, uuid, nextTrackIndex: nextTrack.index },
+      {
+        error,
+        nextPlaylistNumber: nextTrack.playlistNumber,
+        nextTrackIndex: nextTrack.index,
+        uuid,
+      },
       "Failed to transfer call to queued phone radio track",
     );
     res.status(502).json({
@@ -185,13 +259,87 @@ routes.post("/input/digit", async (req, res) => {
   }
 });
 
+const playlistInputRequestParser = type({
+  query: {
+    uuid: "string",
+  },
+  body: {
+    "digits?": "string",
+    "dtmf?": {
+      "digits?": "string",
+    },
+  },
+  locals: {
+    baseUrl: "string",
+  },
+});
+
+routes.post("/input/playlist", async (req, res) => {
+  const request = playlistInputRequestParser(req);
+  if (request instanceof type.errors) {
+    res.status(400).json({
+      error: request.summary,
+    });
+    return;
+  }
+
+  const {
+    locals: { baseUrl: url },
+    query: { uuid },
+  } = request;
+
+  const digits = request.body.digits ?? request.body.dtmf?.digits;
+  const selectedTrack = await playlistService.switchPlaylistByNumber(
+    uuid,
+    digits,
+  );
+
+  if (selectedTrack) {
+    res.json(
+      buildTrackNcco({
+        url,
+        uuid,
+        playlistNumber: selectedTrack.playlistNumber,
+        trackIndex: selectedTrack.index,
+        announceTrack: true,
+        messages: [`Playlist ${selectedTrack.playlistName}.`],
+      }),
+    );
+    return;
+  }
+
+  const currentTrack = await playlistService.getCurrentTrack(uuid);
+
+  if (!currentTrack) {
+    await playlistService.resumePlayback(uuid);
+    res.status(404).json({
+      error: "Current track could not be found.",
+    });
+    return;
+  }
+
+  await playlistService.resumePlayback(uuid);
+
+  res.json(
+    buildTrackNcco({
+      url,
+      uuid,
+      playlistNumber: currentTrack.playlistNumber,
+      trackIndex: currentTrack.index,
+      announceTrack: false,
+      messages: ["Playlist not found."],
+    }),
+  );
+});
+
 const loadTrackRequestParser = type({
   params: {
+    playlistNumber: "string",
     index: "string",
   },
 });
 
-routes.get("/track/:index", async (req, res) => {
+routes.get("/track/:playlistNumber/:index", async (req, res) => {
   const request = loadTrackRequestParser(req);
   if (request instanceof type.errors) {
     res.status(400).json({
@@ -200,9 +348,12 @@ routes.get("/track/:index", async (req, res) => {
     return;
   }
 
-  const { index } = request.params;
+  const { index, playlistNumber } = request.params;
 
-  const track = await playlistService.getTrackPath(parseInt(index));
+  const track = await playlistService.getTrackPath(
+    playlistNumber,
+    parseInt(index),
+  );
 
   if (!track) {
     res.status(404).send("Track not found.");

--- a/phone-radio/src/utils/buildPlaylistSelectionNcco.ts
+++ b/phone-radio/src/utils/buildPlaylistSelectionNcco.ts
@@ -1,0 +1,31 @@
+type BuildPlaylistSelectionNccoOptions = {
+  url: string;
+  uuid: string;
+};
+
+export function buildPlaylistSelectionNcco({
+  url,
+  uuid,
+}: BuildPlaylistSelectionNccoOptions) {
+  const inputUrl = new URL("/input/playlist", url);
+  inputUrl.searchParams.set("uuid", uuid);
+
+  return [
+    {
+      action: "talk",
+      text: "Press tbe playlist number followed by the pound sign.",
+    },
+    {
+      action: "input",
+      type: ["dtmf"],
+      dtmf: {
+        maxDigits: 20,
+        submitOnHash: true,
+        timeOut: 10,
+      },
+      eventUrl: [inputUrl.toString()],
+      eventMethod: "POST",
+      mode: "synchronous",
+    },
+  ];
+}

--- a/phone-radio/src/utils/buildPlaylistSelectionNcco.ts
+++ b/phone-radio/src/utils/buildPlaylistSelectionNcco.ts
@@ -13,7 +13,7 @@ export function buildPlaylistSelectionNcco({
   return [
     {
       action: "talk",
-      text: "Press tbe playlist number followed by the pound sign.",
+      text: "Press the playlist number followed by the pound sign.",
     },
     {
       action: "input",

--- a/phone-radio/src/utils/buildTrackNcco.ts
+++ b/phone-radio/src/utils/buildTrackNcco.ts
@@ -4,17 +4,28 @@ import { vonageApiSecret } from "../clients.js";
 type BuildTrackNccoOptions = {
   url: string;
   uuid: string;
+  playlistNumber: string;
   trackIndex: number;
   announceTrack: boolean;
+  messages?: string[];
 };
 
 export function buildTrackNcco({
   url,
   uuid,
+  playlistNumber,
   trackIndex,
   announceTrack,
+  messages = [],
 }: BuildTrackNccoOptions) {
   const callControl = new NCCOBuilder();
+
+  for (const message of messages) {
+    callControl.addAction({
+      action: "talk",
+      text: message,
+    });
+  }
 
   if (announceTrack) {
     callControl.addAction({
@@ -32,12 +43,18 @@ export function buildTrackNcco({
       eventMethod: "POST",
     })
     .addAction(
-      new Stream(`${url}/track/${trackIndex}?secret=${vonageApiSecret}`),
+      new Stream(
+        `${url}/track/${encodeURIComponent(
+          playlistNumber,
+        )}/${trackIndex}?secret=${vonageApiSecret}`,
+      ),
     )
     .addAction(
       new Notify(
         { uuid },
-        `${url}/track/finished/${uuid}/${trackIndex}`,
+        `${url}/track/finished/${encodeURIComponent(
+          uuid,
+        )}/${encodeURIComponent(playlistNumber)}/${trackIndex}`,
         "POST",
       ),
     );

--- a/phone-radio/test/playlist.service.test.ts
+++ b/phone-radio/test/playlist.service.test.ts
@@ -2,17 +2,37 @@ import { stat } from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { redisClient } from "../src/clients.js";
 import { playlistService } from "../src/playlist.service.js";
-import { tracks } from "../src/tracks.js";
+
+const playlistFixtures = vi.hoisted(() => ({
+  playlists: [
+    {
+      number: "1",
+      name: "Default",
+      tracks: ["default-0.mp3", "default-1.mp3", "default-2.mp3"],
+    },
+    {
+      number: "22",
+      name: "Workout",
+      tracks: ["workout-0.mp3", "workout-1.mp3"],
+    },
+  ],
+}));
+const redisPipeline = vi.hoisted(() => ({
+  exec: vi.fn(),
+  set: vi.fn(),
+}));
 
 vi.mock("../src/clients.js", () => ({
   redisClient: {
     get: vi.fn(),
+    pipeline: vi.fn(() => redisPipeline),
     set: vi.fn(),
   },
 }));
 
-vi.mock("../src/tracks.js", () => ({
-  tracks: ["track-0.mp3", "track-1.mp3", "track-2.mp3"],
+vi.mock("../src/playlists/index.js", () => ({
+  DEFAULT_PLAYLIST_NUMBER: "1",
+  playlists: playlistFixtures.playlists,
 }));
 
 vi.mock("node:fs/promises", () => ({
@@ -21,21 +41,21 @@ vi.mock("node:fs/promises", () => ({
 
 beforeEach(() => {
   vi.mocked(redisClient.get).mockReset();
+  vi.mocked(redisClient.pipeline).mockClear();
   vi.mocked(redisClient.set).mockReset();
   vi.mocked(redisClient.set).mockResolvedValue("OK");
+  redisPipeline.exec.mockReset();
+  redisPipeline.exec.mockResolvedValue([]);
+  redisPipeline.set.mockReset();
+  redisPipeline.set.mockReturnValue(redisPipeline);
   vi.mocked(stat).mockReset();
-  tracks.splice(
-    0,
-    tracks.length,
-    "track-0.mp3",
-    "track-1.mp3",
-    "track-2.mp3",
-  );
   vi.mocked(stat).mockImplementation(async (filePath) => {
     const fileSizesByPath: Record<string, number> = {
-      "track-0.mp3": 100,
-      "track-1.mp3": 200,
-      "track-2.mp3": 300,
+      "default-0.mp3": 100,
+      "default-1.mp3": 200,
+      "default-2.mp3": 300,
+      "workout-0.mp3": 400,
+      "workout-1.mp3": 500,
     };
     const size = fileSizesByPath[String(filePath)];
 
@@ -47,223 +67,311 @@ beforeEach(() => {
   });
 });
 
+function mockCurrentState({
+  mode = "playing",
+  playlistNumber = "1",
+  trackIndex = "0",
+}: {
+  mode?: string | null;
+  playlistNumber?: string | null;
+  trackIndex?: string | null;
+}) {
+  vi.mocked(redisClient.get).mockImplementation(async (key) => {
+    if (String(key).endsWith(":mode")) {
+      return mode;
+    }
+
+    if (String(key).endsWith(":playlist")) {
+      return playlistNumber;
+    }
+
+    if (String(key).endsWith(":track")) {
+      return trackIndex;
+    }
+
+    return null;
+  });
+}
+
 describe("startPlaylist", () => {
-  it("stores the listener at the first track", async () => {
+  it("stores the listener on the default playlist at the first track in one pipeline", async () => {
     await playlistService.startPlaylist("call-1");
 
-    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", "0");
+    expect(redisClient.pipeline).toHaveBeenCalledTimes(1);
+    expect(redisPipeline.set).toHaveBeenCalledWith(
+      "listener:call-1:playlist",
+      "1",
+    );
+    expect(redisPipeline.set).toHaveBeenCalledWith(
+      "listener:call-1:track",
+      "0",
+    );
+    expect(redisPipeline.set).toHaveBeenCalledWith(
+      "listener:call-1:mode",
+      "playing",
+    );
+    expect(redisPipeline.exec).toHaveBeenCalledTimes(1);
+    expect(redisClient.set).not.toHaveBeenCalled();
   });
 
-  it("overwrites without reading the previous listener index", async () => {
+  it("overwrites without reading the previous listener state", async () => {
     await playlistService.startPlaylist("call-1");
 
     expect(redisClient.get).not.toHaveBeenCalled();
-    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", "0");
+  });
+});
+
+describe("playlist selection mode", () => {
+  it("marks a listener as selecting a playlist", async () => {
+    await playlistService.startPlaylistSelection("call-1");
+
+    expect(redisClient.set).toHaveBeenCalledWith(
+      "listener:call-1:mode",
+      "selecting-playlist",
+    );
+  });
+
+  it("marks a listener as playing again", async () => {
+    await playlistService.resumePlayback("call-1");
+
+    expect(redisClient.set).toHaveBeenCalledWith(
+      "listener:call-1:mode",
+      "playing",
+    );
   });
 });
 
 describe("getCurrentTrack", () => {
-  it("returns the current track with file metadata", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("1");
+  it("returns the current playlist track with file metadata", async () => {
+    mockCurrentState({ playlistNumber: "22", trackIndex: "1" });
 
     await expect(playlistService.getCurrentTrack("call-1")).resolves.toEqual({
-      filePath: "track-1.mp3",
-      fileSize: 200,
+      filePath: "workout-1.mp3",
+      fileSize: 500,
       index: 1,
+      playlistNumber: "22",
+      playlistName: "Workout",
     });
-    expect(redisClient.get).toHaveBeenCalledWith("listener:call-1:track");
-    expect(stat).toHaveBeenCalledWith("track-1.mp3");
+    expect(stat).toHaveBeenCalledWith("workout-1.mp3");
+  });
+
+  it("defaults old listener state to the default playlist when no playlist key exists", async () => {
+    mockCurrentState({ playlistNumber: null, trackIndex: "2" });
+
+    await expect(playlistService.getCurrentTrack("call-1")).resolves.toEqual({
+      filePath: "default-2.mp3",
+      fileSize: 300,
+      index: 2,
+      playlistNumber: "1",
+      playlistName: "Default",
+    });
   });
 
   it("returns null when Redis has no index for the listener", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce(null);
+    mockCurrentState({ trackIndex: null });
 
     await expect(playlistService.getCurrentTrack("call-1")).resolves.toBeNull();
     expect(stat).not.toHaveBeenCalled();
   });
 
+  it("returns null when the stored playlist number is invalid", async () => {
+    mockCurrentState({ playlistNumber: "missing", trackIndex: "1" });
+
+    await expect(playlistService.getCurrentTrack("call-1")).resolves.toBeNull();
+  });
+
   it("returns null when the stored index is invalid", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("not-a-number");
+    mockCurrentState({ trackIndex: "not-a-number" });
 
     await expect(playlistService.getCurrentTrack("call-1")).resolves.toBeNull();
   });
 
-  it("returns null when the stored index is outside the track list", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("99");
-
-    await expect(playlistService.getCurrentTrack("call-1")).resolves.toBeNull();
-  });
-
-  it("returns null when stat fails for the current track", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("1");
-    vi.mocked(stat).mockRejectedValueOnce(new Error("missing file"));
-
-    await expect(playlistService.getCurrentTrack("call-1")).resolves.toBeNull();
-  });
-
-  it("returns null when Redis get fails", async () => {
-    vi.mocked(redisClient.get).mockRejectedValueOnce(
-      new Error("redis unavailable"),
-    );
+  it("returns null when the stored index is outside the active playlist", async () => {
+    mockCurrentState({ playlistNumber: "22", trackIndex: "99" });
 
     await expect(playlistService.getCurrentTrack("call-1")).resolves.toBeNull();
   });
 });
 
 describe("getTrackPath", () => {
-  it("returns the requested track with file metadata", async () => {
-    await expect(playlistService.getTrackPath(2)).resolves.toEqual({
-      filePath: "track-2.mp3",
-      fileSize: 300,
+  it("returns a requested track by playlist number and index", async () => {
+    await expect(playlistService.getTrackPath("22", 1)).resolves.toEqual({
+      filePath: "workout-1.mp3",
+      fileSize: 500,
     });
-    expect(stat).toHaveBeenCalledWith("track-2.mp3");
+    expect(stat).toHaveBeenCalledWith("workout-1.mp3");
   });
 
-  it("returns null when the index is outside the track list", async () => {
-    await expect(playlistService.getTrackPath(3)).resolves.toBeNull();
+  it("returns null when the playlist number is unknown", async () => {
+    await expect(playlistService.getTrackPath("missing", 0)).resolves.toBeNull();
   });
 
-  it("returns null when stat fails", async () => {
-    vi.mocked(stat).mockRejectedValueOnce(new Error("missing file"));
-
-    await expect(playlistService.getTrackPath(0)).resolves.toBeNull();
+  it("returns null when the index is outside the playlist", async () => {
+    await expect(playlistService.getTrackPath("22", 3)).resolves.toBeNull();
   });
 });
 
 describe("trackFinished", () => {
-  it("advances to the next track when the completed index matches Redis", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("1");
+  it("advances within the active playlist when the callback matches Redis", async () => {
+    mockCurrentState({ playlistNumber: "22", trackIndex: "0" });
 
-    await expect(playlistService.trackFinished("call-1", 1)).resolves.toEqual({
-      filePath: "track-2.mp3",
-      fileSize: 300,
-      index: 2,
+    await expect(
+      playlistService.trackFinished("call-1", "22", 0),
+    ).resolves.toEqual({
+      filePath: "workout-1.mp3",
+      fileSize: 500,
+      index: 1,
+      playlistNumber: "22",
+      playlistName: "Workout",
     });
-    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", 2);
+    expect(redisClient.set).toHaveBeenCalledWith(
+      "listener:call-1:playlist",
+      "22",
+    );
+    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", "1");
   });
 
-  it("wraps to the first track after the last track finishes", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("2");
+  it("wraps to the first track after the last active playlist track finishes", async () => {
+    mockCurrentState({ playlistNumber: "22", trackIndex: "1" });
 
-    await expect(playlistService.trackFinished("call-1", 2)).resolves.toEqual({
-      filePath: "track-0.mp3",
-      fileSize: 100,
+    await expect(
+      playlistService.trackFinished("call-1", "22", 1),
+    ).resolves.toMatchObject({
+      filePath: "workout-0.mp3",
       index: 0,
+      playlistNumber: "22",
     });
-    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", 0);
   });
 
-  it("returns null and leaves Redis unchanged when the completed index is stale", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("2");
+  it("ignores stale finished callbacks from a previous playlist", async () => {
+    mockCurrentState({ playlistNumber: "22", trackIndex: "0" });
 
-    await expect(playlistService.trackFinished("call-1", 1)).resolves.toBeNull();
+    await expect(
+      playlistService.trackFinished("call-1", "1", 0),
+    ).resolves.toBeNull();
     expect(redisClient.set).not.toHaveBeenCalled();
   });
 
-  it("returns null when there is no current track", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce(null);
+  it("ignores finished callbacks while the listener is selecting a playlist", async () => {
+    mockCurrentState({
+      mode: "selecting-playlist",
+      playlistNumber: "22",
+      trackIndex: "0",
+    });
 
-    await expect(playlistService.trackFinished("call-1", 0)).resolves.toBeNull();
+    await expect(
+      playlistService.trackFinished("call-1", "22", 0),
+    ).resolves.toBeNull();
     expect(redisClient.set).not.toHaveBeenCalled();
   });
 
-  it("does not reread Redis after validating the completed track", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("0");
+  it("ignores stale finished callbacks from a previous track index", async () => {
+    mockCurrentState({ playlistNumber: "22", trackIndex: "1" });
 
-    await playlistService.trackFinished("call-1", 0);
-
-    expect(redisClient.get).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns null and leaves Redis unchanged when the next track stat fails", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("0");
-    vi.mocked(stat)
-      .mockResolvedValueOnce({ size: 100 } as Awaited<ReturnType<typeof stat>>)
-      .mockRejectedValueOnce(new Error("missing next file"));
-
-    await expect(playlistService.trackFinished("call-1", 0)).resolves.toBeNull();
+    await expect(
+      playlistService.trackFinished("call-1", "22", 0),
+    ).resolves.toBeNull();
     expect(redisClient.set).not.toHaveBeenCalled();
   });
 });
 
-describe("toNextTrack", () => {
-  it("advances from the current track to the next track", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("0");
+describe("next and previous track previews", () => {
+  it("previews the next track without committing Redis state", async () => {
+    mockCurrentState({ playlistNumber: "1", trackIndex: "0" });
 
-    await expect(playlistService.toNextTrack("call-1")).resolves.toEqual({
-      filePath: "track-1.mp3",
-      fileSize: 200,
+    await expect(playlistService.getNextTrack("call-1")).resolves.toMatchObject(
+      {
+        filePath: "default-1.mp3",
+        index: 1,
+        playlistNumber: "1",
+      },
+    );
+    expect(redisClient.set).not.toHaveBeenCalled();
+  });
+
+  it("previews the previous track without committing Redis state", async () => {
+    mockCurrentState({ playlistNumber: "1", trackIndex: "0" });
+
+    await expect(
+      playlistService.getPreviousTrack("call-1"),
+    ).resolves.toMatchObject({
+      filePath: "default-2.mp3",
+      index: 2,
+      playlistNumber: "1",
+    });
+    expect(redisClient.set).not.toHaveBeenCalled();
+  });
+
+  it("keeps the next-track wrapper for non-transfer callers", async () => {
+    mockCurrentState({ playlistNumber: "1", trackIndex: "0" });
+
+    await expect(playlistService.toNextTrack("call-1")).resolves.toMatchObject({
+      filePath: "default-1.mp3",
       index: 1,
+      playlistNumber: "1",
     });
-    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", 1);
+    expect(redisClient.set).toHaveBeenCalledWith(
+      "listener:call-1:playlist",
+      "1",
+    );
+    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", "1");
   });
 
-  it("wraps from the last track to the first track", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("2");
+  it("keeps the previous-track wrapper for non-transfer callers", async () => {
+    mockCurrentState({ playlistNumber: "1", trackIndex: "0" });
 
-    await expect(playlistService.toNextTrack("call-1")).resolves.toEqual({
-      filePath: "track-0.mp3",
-      fileSize: 100,
-      index: 0,
+    await expect(
+      playlistService.toPreviousTrack("call-1"),
+    ).resolves.toMatchObject({
+      filePath: "default-2.mp3",
+      index: 2,
+      playlistNumber: "1",
     });
-    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", 0);
+    expect(redisClient.set).toHaveBeenCalledWith(
+      "listener:call-1:playlist",
+      "1",
+    );
+    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", "2");
   });
 
-  it("returns null when there is no current track", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce(null);
-
-    await expect(playlistService.toNextTrack("call-1")).resolves.toBeNull();
-    expect(redisClient.set).not.toHaveBeenCalled();
-  });
-
-  it("returns null and leaves Redis unchanged when the next track stat fails", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("0");
-    vi.mocked(stat)
-      .mockResolvedValueOnce({ size: 100 } as Awaited<ReturnType<typeof stat>>)
-      .mockRejectedValueOnce(new Error("missing next file"));
-
-    await expect(playlistService.toNextTrack("call-1")).resolves.toBeNull();
-    expect(redisClient.set).not.toHaveBeenCalled();
+  it("commits a validated target track", async () => {
+    await expect(
+      playlistService.commitTrack("call-1", "22", 1),
+    ).resolves.toMatchObject({
+      filePath: "workout-1.mp3",
+      index: 1,
+      playlistNumber: "22",
+    });
+    expect(redisClient.set).toHaveBeenCalledWith(
+      "listener:call-1:playlist",
+      "22",
+    );
+    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", "1");
   });
 });
 
-describe("toPreviousTrack", () => {
-  it("rewinds from the current track to the previous track", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("2");
-
-    await expect(playlistService.toPreviousTrack("call-1")).resolves.toEqual({
-      filePath: "track-1.mp3",
-      fileSize: 200,
-      index: 1,
+describe("switchPlaylistByNumber", () => {
+  it("switches to the selected playlist and starts at track zero", async () => {
+    await expect(
+      playlistService.switchPlaylistByNumber("call-1", "22#"),
+    ).resolves.toEqual({
+      filePath: "workout-0.mp3",
+      fileSize: 400,
+      index: 0,
+      playlistNumber: "22",
+      playlistName: "Workout",
     });
-    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", 1);
+    expect(redisClient.set).toHaveBeenCalledWith(
+      "listener:call-1:playlist",
+      "22",
+    );
+    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", "0");
   });
 
-  it("wraps from the first track to the last track", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("0");
-
-    await expect(playlistService.toPreviousTrack("call-1")).resolves.toEqual({
-      filePath: "track-2.mp3",
-      fileSize: 300,
-      index: 2,
-    });
-    expect(redisClient.set).toHaveBeenCalledWith("listener:call-1:track", 2);
-  });
-
-  it("returns null when there is no current track", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce(null);
-
-    await expect(playlistService.toPreviousTrack("call-1")).resolves.toBeNull();
-    expect(redisClient.set).not.toHaveBeenCalled();
-  });
-
-  it("returns null and leaves Redis unchanged when the previous track stat fails", async () => {
-    vi.mocked(redisClient.get).mockResolvedValueOnce("0");
-    vi.mocked(stat)
-      .mockResolvedValueOnce({ size: 100 } as Awaited<ReturnType<typeof stat>>)
-      .mockRejectedValueOnce(new Error("missing previous file"));
-
-    await expect(playlistService.toPreviousTrack("call-1")).resolves.toBeNull();
+  it("returns null and leaves Redis unchanged for an unknown playlist number", async () => {
+    await expect(
+      playlistService.switchPlaylistByNumber("call-1", "99"),
+    ).resolves.toBeNull();
     expect(redisClient.set).not.toHaveBeenCalled();
   });
 });

--- a/phone-radio/test/routes.test.ts
+++ b/phone-radio/test/routes.test.ts
@@ -132,9 +132,9 @@ async function invokeRoute(routePath: string, options: InvokeRouteOptions = {}) 
 }
 
 describe("POST /input/digit", () => {
-  it("transfers digit 9 to the playlist selector NCCO", async () => {
+  it("transfers pound sign to the playlist selector NCCO", async () => {
     const response = await invokeRoute("/input/digit", {
-      body: { digit: "9" },
+      body: { digit: "#" },
       query: { uuid: "call-1" },
     });
 
@@ -145,7 +145,7 @@ describe("POST /input/digit", () => {
     expect(voiceClient.transferCallWithNCCO).toHaveBeenCalledWith("call-1", [
       {
         action: "talk",
-        text: "Press any number followed by the pound sign.",
+        text: "Press the playlist number followed by the pound sign.",
       },
       {
         action: "input",
@@ -170,7 +170,7 @@ describe("POST /input/digit", () => {
     );
 
     const response = await invokeRoute("/input/digit", {
-      body: { digit: "9" },
+      body: { digit: "#" },
       query: { uuid: "call-1" },
     });
 
@@ -179,6 +179,17 @@ describe("POST /input/digit", () => {
       "call-1",
     );
     expect(playlistService.resumePlayback).toHaveBeenCalledWith("call-1");
+  });
+
+  it("does not use digit 9 for playlist selection", async () => {
+    const response = await invokeRoute("/input/digit", {
+      body: { digit: "9" },
+      query: { uuid: "call-1" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(playlistService.startPlaylistSelection).not.toHaveBeenCalled();
+    expect(voiceClient.transferCallWithNCCO).not.toHaveBeenCalled();
   });
 
   it("transfers skip targets before committing the Redis track state", async () => {

--- a/phone-radio/test/routes.test.ts
+++ b/phone-radio/test/routes.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { voiceClient } from "../src/clients.js";
+import { playlistService, type PlaylistTrack } from "../src/playlist.service.js";
+import { routes } from "../src/routes.js";
+
+vi.mock("../src/clients.js", () => ({
+  vonageApiSecret: "test-secret",
+  voiceClient: {
+    playDTMF: vi.fn(),
+    subscribeDTMF: vi.fn(),
+    transferCallWithNCCO: vi.fn(),
+  },
+}));
+
+vi.mock("../src/playlist.service.js", () => ({
+  playlistService: {
+    commitTrack: vi.fn(),
+    getCurrentTrack: vi.fn(),
+    getNextTrack: vi.fn(),
+    getPreviousTrack: vi.fn(),
+    getTrackPath: vi.fn(),
+    resumePlayback: vi.fn(),
+    startPlaylist: vi.fn(),
+    startPlaylistSelection: vi.fn(),
+    switchPlaylistByNumber: vi.fn(),
+    trackFinished: vi.fn(),
+  },
+}));
+
+const defaultTrack: PlaylistTrack = {
+  filePath: "default-2.mp3",
+  fileSize: 300,
+  index: 2,
+  playlistNumber: "1",
+  playlistName: "Default",
+};
+
+const workoutTrack: PlaylistTrack = {
+  filePath: "workout-0.mp3",
+  fileSize: 400,
+  index: 0,
+  playlistNumber: "22",
+  playlistName: "Workout",
+};
+
+beforeEach(() => {
+  vi.mocked(voiceClient.playDTMF).mockReset();
+  vi.mocked(voiceClient.subscribeDTMF).mockReset();
+  vi.mocked(voiceClient.transferCallWithNCCO).mockReset();
+  vi.mocked(voiceClient.transferCallWithNCCO).mockResolvedValue({});
+
+  vi.mocked(playlistService.commitTrack).mockReset();
+  vi.mocked(playlistService.getCurrentTrack).mockReset();
+  vi.mocked(playlistService.getNextTrack).mockReset();
+  vi.mocked(playlistService.getPreviousTrack).mockReset();
+  vi.mocked(playlistService.getTrackPath).mockReset();
+  vi.mocked(playlistService.resumePlayback).mockReset();
+  vi.mocked(playlistService.startPlaylist).mockReset();
+  vi.mocked(playlistService.startPlaylistSelection).mockReset();
+  vi.mocked(playlistService.switchPlaylistByNumber).mockReset();
+  vi.mocked(playlistService.trackFinished).mockReset();
+  vi.mocked(playlistService.resumePlayback).mockResolvedValue();
+  vi.mocked(playlistService.startPlaylistSelection).mockResolvedValue();
+});
+
+type InvokeRouteOptions = {
+  body?: unknown;
+  params?: Record<string, string>;
+  query?: Record<string, string>;
+};
+
+async function invokeRoute(routePath: string, options: InvokeRouteOptions = {}) {
+  const layer = (routes as unknown as { stack: unknown[] }).stack.find(
+    (stackLayer) =>
+      (stackLayer as { route?: { path: string } }).route?.path === routePath,
+  ) as
+    | {
+        route: {
+          stack: {
+            handle: (
+              req: unknown,
+              res: unknown,
+              next: (error?: unknown) => void,
+            ) => unknown;
+          }[];
+        };
+      }
+    | undefined;
+
+  if (!layer) {
+    throw new Error(`Route ${routePath} was not registered`);
+  }
+
+  const response = {
+    body: undefined as unknown,
+    statusCode: 200,
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    send(payload?: unknown) {
+      this.body = payload;
+      return this;
+    },
+    status(statusCode: number) {
+      this.statusCode = statusCode;
+      return this;
+    },
+  };
+  const request = {
+    body: options.body ?? {},
+    locals: {
+      baseUrl: "https://radio.example.test",
+    },
+    log: {
+      error: vi.fn(),
+      info: vi.fn(),
+    },
+    params: options.params ?? {},
+    query: options.query ?? {},
+  };
+
+  await Promise.resolve(
+    layer.route.stack[0].handle(request, response, (error?: unknown) => {
+      if (error) {
+        throw error;
+      }
+    }),
+  );
+
+  return response;
+}
+
+describe("POST /input/digit", () => {
+  it("transfers digit 9 to the playlist selector NCCO", async () => {
+    const response = await invokeRoute("/input/digit", {
+      body: { digit: "9" },
+      query: { uuid: "call-1" },
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(playlistService.startPlaylistSelection).toHaveBeenCalledWith(
+      "call-1",
+    );
+    expect(voiceClient.transferCallWithNCCO).toHaveBeenCalledWith("call-1", [
+      {
+        action: "talk",
+        text: "Press any number followed by the pound sign.",
+      },
+      {
+        action: "input",
+        type: ["dtmf"],
+        dtmf: {
+          maxDigits: 20,
+          submitOnHash: true,
+          timeOut: 10,
+        },
+        eventUrl: [
+          "https://radio.example.test/input/playlist?uuid=call-1",
+        ],
+        eventMethod: "POST",
+        mode: "synchronous",
+      },
+    ]);
+  });
+
+  it("resumes playback mode when playlist selector transfer fails", async () => {
+    vi.mocked(voiceClient.transferCallWithNCCO).mockRejectedValue(
+      new Error("vonage unavailable"),
+    );
+
+    const response = await invokeRoute("/input/digit", {
+      body: { digit: "9" },
+      query: { uuid: "call-1" },
+    });
+
+    expect(response.statusCode).toBe(502);
+    expect(playlistService.startPlaylistSelection).toHaveBeenCalledWith(
+      "call-1",
+    );
+    expect(playlistService.resumePlayback).toHaveBeenCalledWith("call-1");
+  });
+
+  it("transfers skip targets before committing the Redis track state", async () => {
+    vi.mocked(playlistService.getNextTrack).mockResolvedValue(workoutTrack);
+    vi.mocked(playlistService.commitTrack).mockResolvedValue(workoutTrack);
+
+    const response = await invokeRoute("/input/digit", {
+      body: { digit: "2" },
+      query: { uuid: "call-1" },
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(voiceClient.transferCallWithNCCO).toHaveBeenCalledWith(
+      "call-1",
+      expect.arrayContaining([
+        expect.objectContaining({ action: "input", mode: "asynchronous" }),
+        expect.objectContaining({
+          action: "stream",
+          streamUrl: [
+            "https://radio.example.test/track/22/0?secret=test-secret",
+          ],
+        }),
+      ]),
+    );
+    expect(playlistService.commitTrack).toHaveBeenCalledWith(
+      "call-1",
+      "22",
+      0,
+    );
+    expect(
+      vi.mocked(voiceClient.transferCallWithNCCO).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(playlistService.commitTrack).mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not commit Redis state when a skip transfer fails", async () => {
+    vi.mocked(playlistService.getPreviousTrack).mockResolvedValue(defaultTrack);
+    vi.mocked(voiceClient.transferCallWithNCCO).mockRejectedValue(
+      new Error("vonage unavailable"),
+    );
+
+    const response = await invokeRoute("/input/digit", {
+      body: { digit: "1" },
+      query: { uuid: "call-1" },
+    });
+
+    expect(response.statusCode).toBe(502);
+    expect(playlistService.commitTrack).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /input/playlist", () => {
+  it("switches to a valid playlist number and returns playback NCCO", async () => {
+    vi.mocked(playlistService.switchPlaylistByNumber).mockResolvedValue(
+      workoutTrack,
+    );
+
+    const response = await invokeRoute("/input/playlist", {
+      body: { dtmf: { digits: "22" } },
+      query: { uuid: "call-1" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(playlistService.switchPlaylistByNumber).toHaveBeenCalledWith(
+      "call-1",
+      "22",
+    );
+    expect(response.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "talk",
+          text: "Playlist Workout.",
+        }),
+        expect.objectContaining({
+          action: "stream",
+          streamUrl: [
+            "https://radio.example.test/track/22/0?secret=test-secret",
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it("returns to current playback when playlist input is invalid", async () => {
+    vi.mocked(playlistService.switchPlaylistByNumber).mockResolvedValue(null);
+    vi.mocked(playlistService.getCurrentTrack).mockResolvedValue(defaultTrack);
+
+    const response = await invokeRoute("/input/playlist", {
+      body: { dtmf: { digits: "99" } },
+      query: { uuid: "call-1" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(playlistService.resumePlayback).toHaveBeenCalledWith("call-1");
+    expect(response.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "talk",
+          text: "Playlist not found.",
+        }),
+        expect.objectContaining({
+          action: "stream",
+          streamUrl: [
+            "https://radio.example.test/track/1/2?secret=test-secret",
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it("resumes playback before returning 404 when invalid input has no current track", async () => {
+    vi.mocked(playlistService.switchPlaylistByNumber).mockResolvedValue(null);
+    vi.mocked(playlistService.getCurrentTrack).mockResolvedValue(null);
+
+    const response = await invokeRoute("/input/playlist", {
+      body: { dtmf: { digits: "99" } },
+      query: { uuid: "call-1" },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(playlistService.resumePlayback).toHaveBeenCalledWith("call-1");
+    expect(response.body).toEqual({
+      error: "Current track could not be found.",
+    });
+  });
+});
+
+describe("POST /track/finished/:uuid/:playlistNumber/:songIndex", () => {
+  it("passes playlist number through to stale callback protection", async () => {
+    vi.mocked(playlistService.trackFinished).mockResolvedValue(null);
+
+    const response = await invokeRoute(
+      "/track/finished/:uuid/:playlistNumber/:songIndex",
+      {
+        params: {
+          playlistNumber: "1",
+          songIndex: "2",
+          uuid: "call-1",
+        },
+      },
+    );
+
+    expect(response.statusCode).toBe(204);
+    expect(playlistService.trackFinished).toHaveBeenCalledWith(
+      "call-1",
+      "1",
+      2,
+    );
+  });
+});

--- a/tickets/TICKETS.md
+++ b/tickets/TICKETS.md
@@ -162,3 +162,4 @@
 - [X] `01-SkipTrackIndexTts.md` — Announce the queued song index before streaming a skipped track
 - [ ] `02-FixDigitTransferCommitOrdering.md` — Defer Redis skip index commits until after Vonage transfer succeeds
 - [ ] `02-FixSetToTrackStatOrdering.md` — Validate target track files before committing Redis index changes
+- [X] `02-PlaylistSelectionRefactor.md` — Add Redis-backed playlist selection by pressing 9 during playback

--- a/tickets/phase16-phone-radio/02-PlaylistSelectionRefactor.md
+++ b/tickets/phase16-phone-radio/02-PlaylistSelectionRefactor.md
@@ -1,0 +1,37 @@
+# Playlist Selection Refactor
+
+Owner: Dev
+Status: Done
+
+## Plan
+
+Phone Radio should support playlist selection during an active call. Pressing `9` at any time opens a playlist-selection prompt, asks the caller to press a playlist number followed by `#`, and moves the active call to the selected playlist.
+
+Use Vonage's synchronous NCCO `input` action with DTMF `submitOnHash` for the playlist selector. Keep the existing asynchronous DTMF subscription during normal playback so `1`, `2`, and `9` remain available while audio is streaming.
+
+## Implementation
+
+- Replace the single `tracks.ts` list with a `playlists/` folder.
+- Add stable playlist metadata with numeric selector codes, names, and track arrays.
+- Store both active playlist number and active track index in Redis:
+  - `listener:{uuid}:playlist`
+  - `listener:{uuid}:track`
+- Default new callers to the default playlist at track `0`.
+- Add a playlist selector NCCO that says "Press any number followed by the pound sign." and posts collected digits to `/input/playlist`.
+- Update playback NCCOs and track routes to include playlist number so stale callbacks from a previous playlist cannot advance the new playlist.
+- Update route handling:
+  - `1`: previous track in active playlist.
+  - `2`: next track in active playlist.
+  - `9`: transfer to playlist selector prompt.
+  - `/input/playlist`: switch to a valid playlist number, or return to current playback after an invalid/empty selection.
+
+## Acceptance Criteria
+
+- [X] New callers start on the default playlist.
+- [X] Pressing `9` transfers the call to a playlist selector prompt.
+- [X] Entering a valid playlist number followed by `#` switches playlists and starts track `0`.
+- [X] Invalid playlist input returns the caller to the current playlist.
+- [X] Track finish callbacks include playlist number and ignore stale playlist callbacks.
+- [X] Unit tests cover playlist state, selector input, route behavior, and stale callback protection.
+- [X] `pnpm --filter phone-radio test` passes.
+- [X] `pnpm --filter phone-radio build` passes.


### PR DESCRIPTION
## Summary

- Add the Phase 16 Greptile-facing plan/ticket for phone-radio playlist selection.
- Move the old single track array into `phone-radio/src/playlists/default.ts` and add a data-only playlist catalog keyed by playlist number.
- Store active playlist number plus track index in Redis, and add Vonage `submitOnHash` playlist selection behind digit `9`.
- Add route/service unit tests for playlist switching, stale callback protection, and transfer-before-commit skip behavior.

## Validation

- `pnpm --filter phone-radio test`
- `pnpm --filter phone-radio build`

## Notes

- Playlist numbers are the only stable playlist reference; no playlist ids or exported playlist lookup helpers are used.
- Normal playback keeps asynchronous DTMF so `1`, `2`, and `9` remain available during streamed audio.